### PR TITLE
piControl: Parse config file from /mnt/boot

### DIFF
--- a/layers/meta-resin-revpi-core-3/recipes-kernel/picontrol/picontrol.bb
+++ b/layers/meta-resin-revpi-core-3/recipes-kernel/picontrol/picontrol.bb
@@ -7,6 +7,7 @@ inherit module
 SRC_URI = " \
 	git://github.com/RevolutionPi/piControl;branch=revpi-4.14 \
 	file://0001-Use-modules_install-as-wanted-by-yocto.patch \
+	file://0002-Search-config-file-in-mnt-boot.patch \
 "
 
 SRCREV ="f3f4e463d0269d8e4ef2b0a8d599cbf759326427"

--- a/layers/meta-resin-revpi-core-3/recipes-kernel/picontrol/picontrol/0002-Search-config-file-in-mnt-boot.patch
+++ b/layers/meta-resin-revpi-core-3/recipes-kernel/picontrol/picontrol/0002-Search-config-file-in-mnt-boot.patch
@@ -1,0 +1,30 @@
+From 1b18039631adfbc193f96c714ee60e00d28a11b3 Mon Sep 17 00:00:00 2001
+From: Sebastian Panceac <sebastian@resin.io>
+Date: Wed, 29 Aug 2018 09:38:27 +0200
+Subject: [PATCH] Search config file in /mnt/boot
+
+Upstream-status: Inappropriate [configuration]
+Signed-off-by: Sebastian Panceac <sebastian@resin.io>
+---
+ piControl.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/piControl.h b/piControl.h
+index 6f95c83..d46f456 100755
+--- a/piControl.h
++++ b/piControl.h
+@@ -58,9 +58,9 @@
+ 
+ #define PICONTROL_DEVICE        "/dev/piControl0"
+ 
+-// The config file moved to /etc/revpi.
++// The config file is found in /mnt/boot/
+ // If it cannot be found there, the old location should be used.
+-#define PICONFIG_FILE           "/etc/revpi/config.rsc"
++#define PICONFIG_FILE           "/mnt/boot/config.rsc"
+ #define PICONFIG_FILE_WHEEZY    "/opt/KUNBUS/config.rsc"
+ 
+ #define REV_PI_DEV_FIRST_RIGHT      32      // address of first module on the right side of the RevPi Core
+-- 
+2.7.4
+


### PR DESCRIPTION
Set the piControl kernel module to open the config.rsc file from /mnt/boot path
instead of the /etc/revpi path used in Kunbus's image.

Changelog-entry: piControl: Parse config.rsc file from /mnt/boot
Signed-off-by: Sebastian Panceac <sebastian@resin.io>