### PR TITLE
Use kunbus linux kernel 4.9 instead of 4.14, and use their skb branch.

### DIFF
--- a/layers/meta-resin-revpi-core-3/conf/machine/revpi-core-3.conf
+++ b/layers/meta-resin-revpi-core-3/conf/machine/revpi-core-3.conf
@@ -7,8 +7,16 @@ include conf/machine/raspberrypi3.conf
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-kunbus"
 
+PREFERRED_VERSION_linux-raspberrypi = "4.9.%"
+
 KERNEL_DEVICETREE_append = " \
 	overlays/kunbus.dtbo \
+"
+
+# Remove rpi-3-b-plus if building 4.9 kernel, as the dtb is not included in the repo
+# TODO: Go the other way, and add the bcm2710-rpi-3-b-plus.dtb if building 4.9 kernel
+KERNEL_DEVICETREE_remove = " \
+	bcm2710-rpi-3-b-plus.dtb \
 "
 
 KERNEL_MODULE_AUTOLOAD += "piControl"

--- a/layers/meta-resin-revpi-core-3/recipes-kernel/linux/linux-kunbus.bb
+++ b/layers/meta-resin-revpi-core-3/recipes-kernel/linux/linux-kunbus.bb
@@ -1,10 +1,30 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-LINUX_VERSION = "4.14.44"
 
-SRCREV = "116b34682888cd607178e50dfae2c5431c6d75cb"
-SRC_URI = " \
-	git://github.com/RevolutionPi/linux;branch=revpi-4.14 \
+# revpi-4.14
+LINUX_VERSION_4_14 = "4.14.44"
+
+SRCREV_4_14 = "e12040d15a0e7c5f3eb40ee8631878ee8e904767"
+SRC_URI_4_14 = " \
+    git://github.com/RevolutionPi/linux;branch=revpi-4.14 \
+ 	file://0001-Revert-cgroup-Disable-cgroup-memory-by-default.patch \
+    "
+
+
+
+# Linux-4.9-skb
+LINUX_VERSION_4_9 = "4.9.76"
+
+SRCREV_4_9 = "550f08be6c209d05181a3dbecae06f0719ce82f0"
+SRC_URI_4_9 = " \
+	git://github.com/RevolutionPi/linux;branch=revpi-4.9-skb \
 "
+
+
+SRCREV = "${@bb.utils.contains("PREFERRED_VERSION_linux-raspberrypi", "4.9.%", "${SRCREV_4_9}", "${SRCREV_4_14}", d)}"
+SRC_URI = "${@bb.utils.contains("PREFERRED_VERSION_linux-raspberrypi", "4.9.%", "${SRC_URI_4_9}", "${SRC_URI_4_14}", d)}"
+LINUX_VERSION = "${@bb.utils.contains("PREFERRED_VERSION_linux-raspberrypi", "4.9.%", "${LINUX_VERSION_4_9}", "${LINUX_VERSION_4_14}", d)}"
+
+LINUX_KERNEL_TYPE = "preempt-rt"
 
 require linux-raspberrypi.inc

--- a/layers/meta-resin-revpi-core-3/recipes-kernel/linux/linux-kunbus.bbappend
+++ b/layers/meta-resin-revpi-core-3/recipes-kernel/linux/linux-kunbus.bbappend
@@ -3,7 +3,6 @@ inherit kernel-resin
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI_append = " \
-	file://0001-Revert-cgroup-Disable-cgroup-memory-by-default.patch \
 	file://0001-Add-kunbus-overlay.patch \
 	"
 
@@ -52,6 +51,31 @@ RESIN_CONFIGS[pca955_gpio_expander] = " \
     CONFIG_GPIO_PCA953X=y \
     CONFIG_GPIO_PCA953X_IRQ=y \
     "
+
+do_configure_prepend_revpi-core-3() {
+    # Configure for Balena OS
+    kernel_configure_variable PREEMPT_RT_FULL=y
+	kernel_configure_variable DEBUG_PREEMPT=n
+	kernel_configure_variable SECURITY=y	        # for ptrace_scope
+	kernel_configure_variable SECURITY_YAMA=y	    # for ptrace_scope
+	kernel_configure_variable INTEGRITY=n	        # for ptrace_scope
+	kernel_configure_variable SUSPEND=y	            # suspend testing
+	kernel_configure_variable PM_WAKELOCKS=y	    # suspend testing
+	kernel_configure_variable RTC_HCTOSYS=y	        # sync from rtc on boot
+	kernel_configure_variable RTC_DRV_PCF2127=y     # sync from rtc on boot
+	kernel_configure_variable I2C_BCM2708=y	        # sync from rtc on boot
+	kernel_configure_variable I2C_BCM2835=y	        # sync from rtc on boot
+	kernel_configure_variable CGROUP_PIDS=y	        # amazon greengrass
+	kernel_configure_variable KS8851=m		        # revpi compact eth1
+	kernel_configure_variable GPIO_74X164=m	        # revpi compact dout
+	kernel_configure_variable TI_DAC082S085=m	    # revpi compact aout
+	kernel_configure_variable MULTIPLEXER=m	        # revpi compact ain mux
+	kernel_configure_variable MUX_GPIO=m	        # revpi compact ain mux
+	kernel_configure_variable IIO_MUX=m	            # revpi compact ain mux
+	kernel_configure_variable CAN_HI311X=m	        # revpi con can
+	kernel_configure_variable USB_DWC2=y	        # alternative to dwc_otg
+	kernel_configure_variable RTL8XXXU_UNTESTED=y	# edimax ew-7811un
+}
 
 RESIN_CONFIGS_append = " max3191x"
 RESIN_CONFIGS[max3191x] = " \

--- a/layers/meta-resin-revpi-core-3/recipes-kernel/picontrol/picontrol.bb
+++ b/layers/meta-resin-revpi-core-3/recipes-kernel/picontrol/picontrol.bb
@@ -4,14 +4,26 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 
 inherit module
 
-SRC_URI = " \
-	git://github.com/RevolutionPi/piControl;branch=revpi-4.14 \
-	file://0001-Use-modules_install-as-wanted-by-yocto.patch \
-	file://0002-Search-config-file-in-mnt-boot.patch \
+# Linux-4.14
+SRCREV_4_14 = "f3f4e463d0269d8e4ef2b0a8d599cbf759326427"
+SRC_URI_4_14 = "git://github.com/RevolutionPi/piControl;branch=revpi-4.14 \
+                file://0001-Use-modules_install-as-wanted-by-yocto.patch \
+                file://0002-Search-config-file-in-mnt-boot.patch \
 "
 
-SRCREV ="f3f4e463d0269d8e4ef2b0a8d599cbf759326427"
+
+# Linux-4.9
+SRCREV_4_9 = "ac30180b7af190beccd2becdb0c8a1766c598598"
+SRC_URI_4_9 = "git://github.com/RevolutionPi/piControl;branch=skb \
+               file://0001-Use-modules_install-as-wanted-by-yocto.patch \
+               file://0002-Search-config-file-in-mnt-boot.patch \
+"
+
+
+SRCREV = "${@bb.utils.contains("PREFERRED_VERSION_linux-raspberrypi", "4.9.%", "${SRCREV_4_9}", "${SRCREV_4_14}", d)}"
+SRC_URI = "${@bb.utils.contains("PREFERRED_VERSION_linux-raspberrypi", "4.9.%", "${SRC_URI_4_9}", "${SRC_URI_4_14}", d)}"
 
 S = "${WORKDIR}/git"
 
 EXTRA_OEMAKE_append = " KDIR=${STAGING_KERNEL_DIR}"
+TARGET_CFLAGS_append = " -I${S} -D__KUNBUSPI_KERNEL__"


### PR DESCRIPTION
revpi-core-3.conf: 
 - Add PREFERRED_VERSION_linux-raspberrypi to override kernel version to 4.9.%
 - Remove bcm2710-rpi-3-b-plus.dtb from device tree, as it is not included in kernel repo. See note below.

linux-kunbus.bb:
 - Add LINUX_KERNEL_TYPE = "preempt-rt".
 - Allow for easy change between 4.9 and 4.14, for easy upgrade later on.

linux-kunbus.bbappend:
 - Add kernel configuration, similar to what kunbus configures in https://github.com/RevolutionPi/imagebakery to build as fully preemptive RT, with all the required drivers.

picontrol.bb:
 - Allow for easy change between 4.9 and 4.14, for easy upgrade later on.

[Issue #24 ]

- Use kernel 4.9 instead of 4.14, as 4.14 still timeouts, even when built as preemptive RT.
- Build the kernel as a fully preemptive RT build.
- Allow quickly changing between 4.9-skb and 4.14, by just changing PREFERRED_VERSION_linux-raspberrypi in revpi-core-3.conf

**NOTE:**
Maybe we should consider adding bcm2710-rpi-3-b-plus.dtb through a patch, instead of removing it from the device tree?  Perhaps someone with the yocto knowledge to do this, can assist with it?

Signed-off-by: Mathias Koch <mk@blackbird.online>